### PR TITLE
Add docker-maven-plugin to Developer Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,7 @@ _Source:_ [What is Docker](https://www.docker.com/what-docker)
 * [Gradle Docker plugin](https://github.com/gesellix/gradle-docker-plugin) - A Docker remote api plugin for Gradle by [@gesellix][gesellix]
 * [powerstrip](https://github.com/clusterhq/powerstrip) - A tool for prototyping Docker extensions by [@clusterhq](https://github.com/clusterhq)
 * [sbt-docker-compose](https://github.com/Tapad/sbt-docker-compose) - Integrates Docker Compose functionality into sbt by [@kurtkopchik](https://github.com/kurtkopchik/)
+* [docker-maven-plugin](https://github.com/spotify/docker-maven-plugin) - A Maven plugin for building and pushing Docker images by [@spotify](https://github.com/spotify/)
 
 ## Development Environments
 * [DevLab](https://github.com/TechnologyAdvice/DevLab) - Utility for running containerized development environments


### PR DESCRIPTION
Added docker-maven-plugin from @spotify.

As you can see in their README, it provides a simple way to create a Docker image with artifacts built from a Maven project.